### PR TITLE
bug(#3): Improve intro padding and post title size for different screens

### DIFF
--- a/src/intro/mod.rs
+++ b/src/intro/mod.rs
@@ -11,7 +11,7 @@ const POSTS: &[(&str, &str)] = &[(
 pub fn Intro() -> Element {
     rsx! {
         div {
-            class: "w-full h-screen flex justify-center p-20",
+            class: "w-full h-screen flex justify-center p-5 md:p-10",
             div {
                 class: "max-w-[40rem]",
                 nav {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ enum Route {
 #[component]
 fn App() -> Element {
     rsx! {
-        document::Link { class: "rounded", rel: "icon", href: FAVICON }
+        document::Link { rel: "icon", href: FAVICON }
         document::Link { rel: "stylesheet", href: TAILWIND_CSS }
         document::Link { rel: "preconnect", href: "https://fonts.googleapis.com" }
         document::Link { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" }

--- a/src/post/mod.rs
+++ b/src/post/mod.rs
@@ -13,7 +13,7 @@ pub fn Post(props: PostProps) -> Element {
         div {
             class: "p-5",
             h2 {
-                class: "text-[48px] font-bold p-4",
+                class: "text-[32px] md:text-[48px] font-bold p-4",
                 "{props.title}"
             }
             Markdown { src: props.src }


### PR DESCRIPTION
Adjust padding in the intro section for better responsiveness on different screen sizes. Modified post title size to be smaller on smaller screens and bigger on larger ones. Removed unused class from favicon link